### PR TITLE
site(windows): fix width to remove horizontal scrollbar

### DIFF
--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -12,7 +12,7 @@
 
 body {
 	height: 100vh;
-	width: 100vw;
+	width: 100%;
 
 	font: 1em/1.5 "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
 


### PR DESCRIPTION
On Windows, when the `body`'s `width` property is set to `100vw` and a vertical scrollbar appears, a horizontal scrollbar will also appears because `100vw` does not account for the vertical scrollbar.

This PR changes `100vw` to `100%` to correct this issue. The horizontal scrollbar will not appear.