### PR TITLE
Fix main page title ("email" to "WebViews")

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -1,5 +1,5 @@
 ---
-title: Support tables for HTML and CSS in emails
+title: Support tables for HTML and CSS in WebViews
 layout: default
 permalink: /
 ---


### PR DESCRIPTION
The title ends up in `<meta>` tags in the generated pages, and is indexed and used as site description by search engines.