### PR TITLE
Move platform descriptions to behavior field

### DIFF
--- a/_features/api-permissions.md
+++ b/_features/api-permissions.md
@@ -8,6 +8,17 @@ notes: ""
 links: {
     "Usage & Challenges report": "https://webview-cg.github.io/usage-and-challenges/#control-api-permissions",
 }
+behaviour: {
+    wkwebview: "Webkit has ways to control microphone and camera, but doesn't support Geolocation.",
+    androidwebview: "Android WebView could use some WebRTC-related events: [WebRTC IP leak](https://github.com/duckduckgo/Android/issues/429).",
+    webview2: "Microsoft's WebView2 support is limited:
+
+* [Feature request: Permissions API](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2427)
+
+* [Feature request: Device or permission \"in use\" event](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2428)
+
+* [Feature request: API for screen sharing](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2442)"
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -32,19 +43,3 @@ stats: {
     }
 }
 ---
-
-# Android WebView
-
-Android WebView could use some WebRTC-related events: [WebRTC IP leak](https://github.com/duckduckgo/Android/issues/429).
-
-# WKWebView
-
-Webkit has ways to control microphone and camera, but doesn't support Geolocation.
-
-# WebView2
-
-Microsoft's WebView2 support is limited:
-
-* [Feature request: Permissions API](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2427)
-* [Feature request: Device or permission "in use" event](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2428)
-* [Feature request: API for screen sharing](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2442)

--- a/_features/autofill.md
+++ b/_features/autofill.md
@@ -8,6 +8,13 @@ last_test_date: "2024-03-29"
 notes: "TODO Comment on how data was tested"
 links: {
 }
+behaviour: {
+    wkwebview: "",
+    androidwebview: "Android WebView relies on the Android autofill framework. Users can choose a default auto fill service, which will be
+responsible for responding to autofill requests. Android WebView is responsible for detecting what fields in a web page
+may need to be auto filled, and is responsible for sending autofill requests to the autofill framework.",
+    webview2: "Will autofill any fields that Microsoft Edge will, such as names, street, email addresses, phone numbers, passwords, etc. Developers can control this in their application using the `CoreWebView2Settings.IsGeneralAutofillEnabled` and `CoreWebView2Settings.IsPasswordAutosaveEnabled` properties."
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -32,17 +39,3 @@ stats: {
     }
 }
 ---
-
-## WebView2
-
-Will autofill any fields that Microsoft Edge will, such as names, street, email addresses, phone numbers, passwords, etc. Developers can control this in their application using the `CoreWebView2Settings.IsGeneralAutofillEnabled` and `CoreWebView2Settings.IsPasswordAutosaveEnabled` properties.
-
-## WKWebView
-
-TODO: Complete me!
-
-## Android WebView
-
-Android WebView relies on the Android autofill framework. Users can choose a default auto fill service, which will be
-responsible for responding to autofill requests. Android WebView is responsible for detecting what fields in a web page
-may need to be auto filled, and is responsible for sending autofill requests to the autofill framework.

--- a/_features/cookies.md
+++ b/_features/cookies.md
@@ -8,6 +8,19 @@ notes: "TODO"
 links: {
     "Blog post about WKWebView changes": "https://blog.merzlabs.com/posts/webview-history/",
 }
+behaviour: {
+    wkwebview: "Intelligent tracking prevention (ITP) was enabled by default for WKWebView on iOS 14
+([reference](https://webkit.org/blog/10882/app-bound-domains/)).
+This means that third party cookies cannot be used by default.
+
+Applications can add the option to opt out of ITP by providing a property to their app configuration for some but not all use cases, but users will
+still have to opt into this behavior in their app settings.
+
+Different WebViews or the native app can also share cookies by using HTTPCookieStorage.",
+    androidwebview: "Third party cookies are disabled by default within Android WebView. Applications can re-enable third party cookies
+using the [CookieManager#setAcceptThirdPartyCookies](https://developer.android.com/reference/android/webkit/CookieManager#setAcceptThirdPartyCookies(android.webkit.WebView,%20boolean)) API.",
+    webview2: "Applications can access, modify, delete, or copy the cookies of their WebView2 instance via the `CoreWebView2.CookieManager` property. By default, WebView2 has [Tracking Prevention](https://learn.microsoft.com/microsoft-edge/web-platform/tracking-prevention) set to \"Balanced\" by default and can be modified using the `CoreWebView2EnvironmentOptions.EnableTrackingPrevention` property."
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -32,26 +45,3 @@ stats: {
     }
 }
 ---
-## WebView2
-
-Applications can access, modify, delete, or copy the cookies of their WebView2 instance via the `CoreWebView2.CookieManager` property. By default, WebView2 has [Tracking Prevention](https://learn.microsoft.com/microsoft-edge/web-platform/tracking-prevention) set to "Balanced" by default and can be modified using the `CoreWebView2EnvironmentOptions.EnableTrackingPrevention` property.
-
-## WKWebView
-
-Intelligent tracking prevention (ITP) was enabled by default for WKWebView on iOS 14
-([reference](https://webkit.org/blog/10882/app-bound-domains/)).
-This means that third party cookies cannot be used by default.
-
-Applications can add the option to opt out of ITP by providing a property to their app configuration for some but not all use cases, but users will
-still have to opt into this behavior in their app settings.
-
-Different WebViews or the native app can also share cookies by using HTTPCookieStorage.
-
-TODO: Complete me!
-
-## Android WebView
-
-Third party cookies are disabled by default within Android WebView. Applications can re-enable third party cookies
-using the [CookieManager#setAcceptThirdPartyCookies](https://developer.android.com/reference/android/webkit/CookieManager#setAcceptThirdPartyCookies(android.webkit.WebView,%20boolean)) API.
-
-## TODO: Any others?

--- a/_features/localhost.md
+++ b/_features/localhost.md
@@ -12,6 +12,11 @@ links: {
     "WKURLSchemehandler": "https://developer.apple.com/documentation/webkit/wkurlschemehandler",
     "WebViewAssetLoader": "https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader"
 }
+behaviour: {
+    wkwebview: "",
+    androidwebview: "",
+    webview2: "WebView2 has a variety of ways to work with local content - intercepting web resources as they're requested, mapping a hostname to a folder on the user's filesystem, or registering a custom URL scheme. You can find details on all of these in WebView2's documentation for [working with local content in WebView2 apps](https://learn.microsoft.com/microsoft-edge/webview2/concepts/working-with-local-content)."
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -36,16 +41,3 @@ stats: {
     }
 }
 ---
-## WebView2
-
-WebView2 has a variety of ways to work with local content - intercepting web resources as they're requested, mapping a hostname to a folder on the user's filesystem, or registering a custom URL scheme. You can find details on all of these in WebView2's documentation for [working with local content in WebView2 apps](https://learn.microsoft.com/microsoft-edge/webview2/concepts/working-with-local-content).
-
-## WKWebView
-
-TODO: Complete me!
-
-## Android WebView
-
-TODO: Complete me!
-
-## TODO: Any others?

--- a/_features/scriptinjection.md
+++ b/_features/scriptinjection.md
@@ -9,6 +9,11 @@ notes: ""
 links: {
     "Usage & Challenges report": "https://webview-cg.github.io/usage-and-challenges/#inject-custom-js-scripts",
 }
+behaviour: {
+    wkwebview: "",
+    androidwebview: "",
+    webview2: ""
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -33,13 +38,3 @@ stats: {
     }
 }
 ---
-
-# Android WebView
-
-TODO
-
-# WKWebView
-
-TODO
-
-# WebView2

--- a/_features/sharing.md
+++ b/_features/sharing.md
@@ -8,6 +8,11 @@ notes: ""
 links: {
     "Usage & Challenges report": "https://webview-cg.github.io/usage-and-challenges/#requests-responses-sharing-and-proxy-between-native-and-webview",
 }
+behaviour: {
+    wkwebview: "",
+    androidwebview: "[shouldInterceptRequest](https://developer.android.com/reference/android/webkit/WebViewClient#shouldInterceptRequest(android.webkit.WebView,%20android.webkit.WebResourceRequest)) in Android WebView provides developers with optional network interception capability. ",
+    webview2: ""
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -32,7 +37,3 @@ stats: {
     }
 }
 ---
-
-# Android WebView
-
-[shouldInterceptRequest](https://developer.android.com/reference/android/webkit/WebViewClient#shouldInterceptRequest(android.webkit.WebView,%20android.webkit.WebResourceRequest)) in Android WebView provides developers with optional network interception capability. 

--- a/_features/template.md
+++ b/_features/template.md
@@ -9,6 +9,11 @@ notes: "TODO Comment on how data was tested"
 links: {
     "Useful link to docs or bugs etc": "https://caniwebview.com/features/localhost/",
 }
+behaviour: {
+    wkwebview: "",
+    androidwebview: "",
+    webview2: ""
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -33,17 +38,3 @@ stats: {
     }
 }
 ---
-
-## WebView2
-
-TODO: Complete me!
-
-## WKWebView
-
-TODO: Complete me!
-
-## Android WebView
-
-TODO: Complete me!
-
-## TODO: Any others?

--- a/_features/updates_cadence.md
+++ b/_features/updates_cadence.md
@@ -8,6 +8,19 @@ last_test_date: "2024-03-29"
 notes: ""
 links: {
 }
+behaviour: {
+    wkwebview: "",
+    androidwebview: "Android WebView is a library provided by the Android operating system. The API itself is a stable surface but Android
+WebView is backed by an updatable library. Android WebView is Chromium based and so it mostly follows the same release
+cycle as Chromium. The schedule for Android WebView releases can be found
+[here](https://chromiumdash.appspot.com/schedule).
+
+Like Chromium, Android WebView has different release channels that users can opt into for testing purposes. You can find
+out more [here](https://chromium.googlesource.com/chromium/src/+/master/android_webview/docs/prerelease.md).",
+    webview2: "WebView2 has two options for updating - Evergreen Runtime or Fixed Runtime. Evergreen runtime is automatically included in recent versions of Windows, and developers can also include a small installer alongside theirs to be confident it's available. This version is updated automatically with major releases every four weeks, roughly following Chromium's releases. When using a fixed runtime, the application developer distributes the WebView2 components with their app and chooses when to update to a newer version. Details on the type of runtimes can be found [here](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution), and details on evergreen updates can be found [here](https://learn.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel).
+
+SDK updates are also every four weeks, and their details are [here](https://learn.microsoft.com/microsoft-edge/webview2/release-notes/about)"
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -32,24 +45,3 @@ stats: {
     }
 }
 ---
-## WebView2
-
-WebView2 has two options for updating - Evergreen Runtime or Fixed Runtime. Evergreen runtime is automatically included in recent versions of Windows, and developers can also include a small installer alongside theirs to be confident it's available. This version is updated automatically with major releases every four weeks, roughly following Chromium's releases. When using a fixed runtime, the application developer distributes the WebView2 components with their app and chooses when to update to a newer version. Details on the type of runtimes can be found [here](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution), and details on evergreen updates can be found [here](https://learn.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel).
-
-SDK updates are also every four weeks, and their details are [here](https://learn.microsoft.com/microsoft-edge/webview2/release-notes/about)
-
-## WKWebView
-
-TODO: Complete me!
-
-## Android WebView
-
-Android WebView is a library provided by the Android operating system. The API itself is a stable surface but Android
-WebView is backed by an updatable library. Android WebView is Chromium based and so it mostly follows the same release
-cycle as Chromium. The schedule for Android WebView releases can be found
-[here](https://chromiumdash.appspot.com/schedule).
-
-Like Chromium, Android WebView has different release channels that users can opt into for testing purposes. You can find
-out more [here](https://chromium.googlesource.com/chromium/src/+/master/android_webview/docs/prerelease.md).
-
-## TODO: Any others?

--- a/_features/web-storage.md
+++ b/_features/web-storage.md
@@ -8,6 +8,14 @@ notes: ""
 links: {
     "Usage & Challenges report": "https://webview-cg.github.io/usage-and-challenges/#manage-web-storage-and-cookies",
 }
+behaviour: {
+    wkwebview: "Webkit provides APIs to retrieve cookies and local/sessionStorage as opaque tokens that can be filtered by hostname. This allows selective removal, although it requires some extra code and workarounds to prevent timing issues (removal is asynchronous).
+<br><br>In Webkit, storage is shared between all WKWebView instances, unless it’s “non persistent” (in memory), which is not ideal for building web browsers.",
+    androidwebview: "In Android WebView, it is not possible to inspect cookie scopes. You can retrieve cookie names and values, but without knowing other attributes it is impossible to override them properly
+
+Android WebView does not provide APIs to manage localStorage/sessionStorage.",
+    webview2: ""
+}
 stats: {
     wkwebview: {
 		macos: {
@@ -32,17 +40,3 @@ stats: {
     }
 }
 ---
-
-# Android WebView
-
-In Android WebView, it is not possible to inspect cookie scopes. You can retrieve cookie names and values, but without knowing other attributes it is impossible to override them properly
-
-Android WebView does not provide APIs to manage localStorage/sessionStorage.
-
-# WKWebView
-
-Webkit provides APIs to retrieve cookies and local/sessionStorage as opaque tokens that can be filtered by hostname. This allows selective removal, although it requires some extra code and workarounds to prevent timing issues (removal is asynchronous).
-
-In Webkit, storage is shared between all WKWebView instances, unless it's "non persistent" (in memory), which is not ideal for building web browsers.
-
-# WebView2

--- a/_layouts/feature.html
+++ b/_layouts/feature.html
@@ -15,11 +15,7 @@ layout: default
 	Showing the behavior description
 	{% endcomment %}
 
-	<h1 class="feature-title">How does it work on each WebView?</h1>
-
 	<div class="data-details">
-		{{ content | markdownify }}
-
 		<div class="data-family-list">
 			{% assign page-families-in-order = "" | split: '' %}
 			{% assign site-families-in-order = site.clients | sort: "display_order" %}
@@ -52,6 +48,7 @@ layout: default
 			{% endcomment %}
 			{% for family in page-families-in-order %}
 			{% assign family-key = family %}
+			{% assign description = page.behaviour[family] %}
 			{% assign family-values = page.stats[family] %}
 			<div class="data-family data-family--{{family-key}}" id="data-{{ page.title | slugify }}-{{ family-key }}">
 				<h3 class="data-family-name">
@@ -83,37 +80,37 @@ layout: default
 						</h4>
 						<div class="data-versions-list">
 							{% for version in platform-values %}
-							{% assign version-key = version | first %}
-							{% assign version-values = version | last | split: ' ' | first %}
-							{% assign version-notes = version | last | split: ' ' | shift %}
-							{% case version-values %}
-							{% when 'y' %}
-							{% assign stat-class-name = 'supported' %}
-							{% when 'n' %}
-							{% assign stat-class-name = 'unsupported' %}
-							{% when 'a' %}
-							{% assign stat-class-name = 'mitigated' %}
-							{% when 'u' %}
-							{% assign stat-class-name = 'unknown' %}
-							{% else %}
-							{% assign stat-class-name = '' %}
-							{% endcase %}
-							<div class="data-version {{ stat-class-name }}">
-								<span class="data-version-number">{{ version-key }}</span>
-								<span class="data-version-badge {{ stat-class-name }}"
-									aria-label="{{ site.data.nicenames.support[stat-class-name] }}"></span>
-								{% if version-notes.size > 0 %}
-								<div class="data-version-notes">
-									{% for note-key in version-notes %}
-									{% assign note-key-slug = note-key | slugify %}
-									<a href="#{{ page.title | slugify }}-cite-note-{{ note-key-slug }}"
-										title="{{ page.notes_by_num[note-key-slug] | markdownify | strip_html }}">{{
-										note-key |
-										replace: '#', '' }}</a>
-									{% endfor %}
+									{% assign version-key = version | first %}
+									{% assign version-values = version | last | split: ' ' | first %}
+									{% assign version-notes = version | last | split: ' ' | shift %}
+								{% case version-values %}
+									{% when 'y' %}
+										{% assign stat-class-name = 'supported' %}
+									{% when 'n' %}
+										{% assign stat-class-name = 'unsupported' %}
+									{% when 'a' %}
+										{% assign stat-class-name = 'mitigated' %}
+									{% when 'u' %}
+										{% assign stat-class-name = 'unknown' %}
+									{% else %}
+										{% assign stat-class-name = '' %}
+								{% endcase %}
+								<div class="data-version {{ stat-class-name }}">
+									<span class="data-version-number">{{ version-key }}</span>
+									<span class="data-version-badge {{ stat-class-name }}"
+										aria-label="{{ site.data.nicenames.support[stat-class-name] }}"></span>
+									{% if version-notes.size > 0 %}
+									<div class="data-version-notes">
+										{% for note-key in version-notes %}
+										{% assign note-key-slug = note-key | slugify %}
+										<a href="#{{ page.title | slugify }}-cite-note-{{ note-key-slug }}"
+											title="{{ page.notes_by_num[note-key-slug] | markdownify | strip_html }}">{{
+											note-key |
+											replace: '#', '' }}</a>
+										{% endfor %}
+									</div>
+									{% endif %}
 								</div>
-								{% endif %}
-							</div>
 							{% endfor %}
 						</div>
 					</div>
@@ -121,23 +118,26 @@ layout: default
 					{% else %}
 					{% assign family-page = site.clients | where:"slug", family-key | first %}
 					{% if family-page != nil and family-page != "" %}
-					{% for platform in family-page.platforms %}
-					{% assign platform-key = platform %}
-					<div class="data-client data-client--{{ platform-key | slugify }}">
-						<h4 class="data-platform-name">
-							{{ site.data.nicenames.platform[platform-key] | default: platform-key }}
-						</h4>
-						<div class="data-versions-list">
-							<div class="data-version unknown">
-								<span class="data-version-number">{{ "now" | date: "%Y-%m" }}</span>
-								<span class="data-version-badge unknown"
-									aria-label="{{ site.data.nicenames.support['unknown'] }}"></span>
+						{% for platform in family-page.platforms %}
+							{% assign platform-key = platform %}
+							<div class="data-client data-client--{{ platform-key | slugify }}">
+								<h4 class="data-platform-name">
+									{{ site.data.nicenames.platform[platform-key] | default: platform-key }}
+								</h4>
+								<div class="data-versions-list">
+									<div class="data-version unknown">
+										<span class="data-version-number">{{ "now" | date: "%Y-%m" }}</span>
+										<span class="data-version-badge unknown"
+											aria-label="{{ site.data.nicenames.support['unknown'] }}"></span>
+									</div>
+								</div>
 							</div>
-						</div>
-					</div>
-					{% endfor %}
+						{% endfor %}
 					{% endif %}
 					{% endif %}
+				</div>
+				<div class="data-family-description">
+					{{description | markdownify}}
 				</div>
 			</div>
 			{% endfor %}

--- a/_sass/_pages/_feature.scss
+++ b/_sass/_pages/_feature.scss
@@ -317,13 +317,15 @@
  * Data
  */
 // Family
-// (ie Outlook, Gmail, …)
+// (ie WKWebView, WebView2, …)
 .data-family-list {
 	display: inline-flex;
-	flex-direction: row;
+	flex-direction: column;
+	gap: rem(16px);
 	justify-content: flex-start;
 	padding-left: rem(16px);
 	padding-right: rem(16px);
+	width: 100%;
 }
 
 .data-family {
@@ -332,17 +334,6 @@
 	flex-direction: column;
 	flex-grow: 1;
 	padding: rem(32px) rem(4px);
-	border-left: 1px solid #454548;
-	max-width: max-content;
-
-	&[hidden] + &:not([hidden]),
-	&:first-child {
-		border-left: none;
-	}
-
-	&:not([hidden]) ~ &:not([hidden]) {
-		border-left: 1px solid #454548;
-	}
 
 	&.selected::before {
 		content: '';
@@ -360,14 +351,14 @@
 
 .data-family-name {
 	display: flex;
-	justify-content: center;
-	align-items: center;
+	justify-content: flex-start;
+	align-items: flex-start;
 	margin: 0 rem(4px);
 	padding: 0 rem(16px);
 	color: rgba(255, 255, 255, 0.85);
-	font-size: rem(16px);
+	font-size: rem(32px);
 	min-height: rem(48px);
-	text-align: center;
+	text-align: left;
 
 	span {
 		position: -webkit-sticky;
@@ -384,6 +375,11 @@
 			}
 		}
 	}
+}
+
+.data-family-description {
+	padding: rem(16px);
+	font-size: rem(20px);
 }
 
 .data-family--thunderbird .data-family-name {


### PR DESCRIPTION
This helps with the styling because we can then display the descriptions inline with the various WebView providers.

This also means that the behaviour data is stored within our data structure. It does mean that we are not fully compliant with caniuse's data structure but as long as we maintain a superset, we should be fine on consuming that data for our own data sources.

Here is an example of how this will look after this change:

![example](https://lh3.googleusercontent.com/u/1/drive-viewer/AKGpiha5dLjlj0weGgiYnnvOduoAjQ5p_zW2EXRiYxNLSBeFwTm5UIjxonT-ZyTxfs3asMZtjjuBToIucMk_WVwkXsLW2q3GM2d6Ow=w3839-h1922-rw-v1)

This also opens the doors to improving the search a little. We can consume this data into the `features.json` and make the search fuzzy search the descriptions.