### PR TITLE
Add bcd features to features search results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
 source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins
+
+gem "jekyll", "= 3.9.5"
 gem "webrick", "~> 1.7"
 gem "kramdown", ">= 2.3.1"
+gem "kramdown-parser-gfm"
+gem "jekyll-mentions"
+gem "jekyll-github-metadata"
+gem "jekyll-default-layout"
+gem 'ffi', '~> 1.9', '>= 1.9.10'
+gem 'httparty'

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,9 @@ collections:
     permalink: /news/:year-:month-:day-:title/
   features:
     output: true
+  genfeatures:
+    output: true
+    permalink: /features/:name/
   clients:
     output: true
 
@@ -11,6 +14,11 @@ defaults:
   - scope:
       path: ""
       type: "features"
+    values:
+      layout: "feature"
+  - scope:
+      path: ""
+      type: "genfeatures"
     values:
       layout: "feature"
   - scope:
@@ -32,8 +40,11 @@ permalink: /:title/
 
 plugins:
   - jekyll-mentions
+  - jekyll-github-metadata
+  - jekyll-default-layout
 
-exclude: [vendor, "Gemfile", "Gemfile.lock", "CONTRIBUTING.md", "LICENSE", "README.md"]
+sass:
+  style: compact
+
+exclude: [vendor, "tools", "Gemfile", "Gemfile.lock", "CONTRIBUTING.md", "LICENSE", "README.md"]
 include: ["_js"]
-
-#incremental: true

--- a/_js/features.json
+++ b/_js/features.json
@@ -3,7 +3,7 @@ layout: null
 permalink: /assets/js/features.json
 ---
 [
-	{% assign features = site.features | sort:'id' %}
+	{% assign features = site.genfeatures | concat: site.features | sort:'id' %}
 	{% for feature in features %}
 		{
 			"slug": {{ feature.slug | jsonify }},

--- a/_plugins/genfeatures.rb
+++ b/_plugins/genfeatures.rb
@@ -1,0 +1,70 @@
+require 'httparty'
+require 'json'
+
+module SamplePlugin
+    class GenfeaturesGenerator < Jekyll::Generator
+      safe true
+  
+      def generate(site)
+        bcd = HTTParty.get("http://unpkg.com/@mdn/browser-compat-data@5.5.31/data.json").body
+        parsed_bcd = JSON.parse(bcd)
+
+        def checkForSupport(feature, platform)
+          return feature['__compat']["support"][platform].kind_of?(Array) || feature['__compat']["support"][platform]["version_added"].class == FalseClass ? 'y'
+          : 'n'
+        end
+
+        parsed_bcd['api'].keys.each do |title|
+          feature = parsed_bcd['api'][title]          
+
+          slug = title.downcase.strip.gsub('_', '-')
+          path = site.in_source_dir("_genfeatures/#{slug}.md")
+          doc = Jekyll::Document.new(path, {
+            :site => site,
+            :collection => site.collections['genfeatures'],
+          })
+
+          doc.data['title'] = title.gsub('-', ' ')
+          doc.data['slug'] = slug
+          doc.data['description'] = feature["__compat"].key?("mdn_url") ? "Read more about this API on [mdn](#{feature["__compat"]["mdn_url"]})."
+          : "TODO"
+          doc.data['category'] = 'webapi'
+          doc.data['keywords'] = 'todo'
+          doc.data['last_test_date'] = parsed_bcd['__meta']['timestamp']
+          doc.data['notes'] = 'Data retrieve from BCD.'
+          doc.data['links'] = []
+          doc.data['behavior'] = {
+            "wkwebview" => "",
+            "androidwebview" => "",
+            "webview2" => ""
+          }
+          doc.data['stats'] = {
+            "wkwebview" => {
+              "macos" => {
+                "*" => "u"
+              },
+              "ios" => {
+                "*" => "u"
+              },
+              "ipados" => {
+                "*" => "u"
+              }
+            },
+            "androidwebview" => {
+              "android" => {
+                "*" => checkForSupport(feature, "webview_android")
+              }
+            },
+            "webview2" => {
+              "windows" => {
+                "*" => "u"
+              }
+            }
+          }
+
+          site.collections['genfeatures'].docs << doc
+        end
+      end
+    end
+
+  end


### PR DESCRIPTION
We can query the a cdn to retrieve a big ol' json full of the bcd.

From that we are able to generate search results. Using a custom plugin to do this.

We will need to change the gitbug action to deploy from a github action but it looks like this is fairly easy. The reason we need to change this is because the github pages gem doesn't allow us to use custom plugins.

Once this is up, we can iterate over it and integrate the data into the rest of the site a little nicer.