### PR TITLE
Add plugin to generate WebView baseline results

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -40,6 +40,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -49,6 +52,11 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      # In order to generate our own baseline results
+      # we use a plugin that calls into node for a utility
+      # method
+      - name: Install node deps
+        run: npm install
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 .DS_Store
 .jekyll-metadata
 _site
+# We generate this data file via a plugin
+# before generating the rest of the sites
+_data/baseline.yml
 Gemfile.lock
+node_modules

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ The WebView Compatibility Data Project is an initiative driven by the [WebView C
 to [make machine-readable data more readily available for documentation platforms and other tools
 ](https://github.com/WebView-CG/charter/blob/04422d7cb3ecc80a7d0f6755135995a74deab64b/charter.md?plain=1#L26).
 
+## Development
+
+Prerequisites:
+- Node
+- Jekyll
+
+Setup:
+- `npm install`.
+
+Run the project:
+- `bundle exec jekyll serve --baseurl=""`.
+
 ## Sub-projects
 
 The compatibility data project has been split into two further sub-projects:
@@ -13,7 +25,10 @@ The compatibility data project has been split into two further sub-projects:
 
 ### Web platform compatibility data
 
-TODO: Complete me!
+This is our effort to improve existing web platform compat data for WebViews.
+We are currently focused on improving support in
+[BCD](https://github.com/mdn/browser-compat-data) and
+[web features](https://github.com/web-platform-dx/web-features/tree/main).
 
 ### WebView behavioral "Feature" data
 

--- a/_plugins/baseline.rb
+++ b/_plugins/baseline.rb
@@ -1,0 +1,15 @@
+# The utility code to compute baseline is distributed through node
+# so the easiest thing for us to do is rather calculate this in
+# node and then process it in jekyll
+
+module Baseline
+	def self.process(site, payload)
+	  return if @processed
+	  system "npm run baseline"
+	  @processed = true
+	end
+  end
+
+  Jekyll::Hooks.register :site, :after_init do |site, payload|
+	Baseline.process(site, payload)
+  end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,253 @@
+{
+  "name": "Compatibility-Data-Project",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@types/node": "^22.7.5",
+        "compute-baseline": "^0.2.0-dev",
+        "node-fetch": "^3.3.2",
+        "tsx": "^4.19.1",
+        "web-features": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+      "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+      "dependencies": {
+        "jsbi": "^4.3.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@mdn/browser-compat-data": {
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.6.7.tgz",
+      "integrity": "sha512-joDR4YZiielxL2h2hN7X2F/mcuaVCW6TRbeEqhk20gPDqdzuFBODk+P4r0wTCGZrvc2Dc4Wnwwk5KyzEpOxy2g==",
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
+    },
+    "node_modules/compute-baseline": {
+      "version": "0.2.0-dev-20241008152122-56b817b",
+      "resolved": "https://registry.npmjs.org/compute-baseline/-/compute-baseline-0.2.0-dev-20241008152122-56b817b.tgz",
+      "integrity": "sha512-x91pwtV4ct/EJLZVW8bWTMp+VXdXg+Bzobcerd/8va0ZQwOVZ5/hk5ZHQl7TZ3lG4Xk5oHgsfO5oxpuWwbhpDA==",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.4.4",
+        "compare-versions": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@mdn/browser-compat-data": "^5.0.0"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+    },
+    "node_modules/tsx": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
+      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "node_modules/web-features": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.0.0.tgz",
+      "integrity": "sha512-v0athEao8WP5wxHO7WFlkS8XoOepeM1vqeT74ERPImqyzY4KENQH67xVnAYka8GeNwYUP9JAmrJSn7pK8uC/zQ=="
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "baseline": "tsx tools/baseline.ts"
+  },
+  "dependencies": {
+    "@types/node": "^22.7.5",
+    "compute-baseline": "^0.2.0-dev",
+    "node-fetch": "^3.3.2",
+    "tsx": "^4.19.1",
+    "web-features": "^2.0.0"
+  }
+}

--- a/pages/baseline.html
+++ b/pages/baseline.html
@@ -1,0 +1,46 @@
+---
+title: Baseline results for WebViews
+layout: default
+permalink: /baseline
+---
+
+<div style="text-align:center">
+	⚠️ This page is under construction ⚠️
+</div>
+
+<div class="baseline">
+	<table>
+		<thead>
+			<th>
+				Feature
+			</th>
+			<th>
+				Description
+			</th>
+			<th>
+				Is baseline
+			</th>
+			<th>
+				Is baseline with WebView
+			</th>
+		</thead>
+		<tbody>
+			{% for baselinefeature in site.data.baseline %}
+				<tr>
+					<td>
+						{{ baselinefeature.name | xml_escape }}
+					</td>
+					<td>
+						{{ baselinefeature.description | xml_escape }}
+					</td>
+					<td>
+						{{ baselinefeature.supported.baseline }}
+					</td>
+					<td>
+						{{ baselinefeature.supported.webviewBaseline }}
+					</td>
+				</tr>
+			{%  endfor %}
+		</tbody>
+	</table>
+</div>

--- a/tools/baseline.ts
+++ b/tools/baseline.ts
@@ -1,0 +1,67 @@
+import { computeBaseline, coreBrowserSet } from "compute-baseline";
+import { Compat } from 'compute-baseline/browser-compat-data';
+import { features } from "web-features";
+import { readFileSync } from 'fs';
+import { writeFile } from 'fs/promises';
+import fetch from 'node-fetch';
+
+const bcdVersion = readFileSync("bcd_version").toString();
+
+type WebViewStatus = boolean | "high" | "low" | "unknown";
+
+const getYml = (
+	name: string,
+	description: string,
+	baseline: boolean | "high" | "low",
+	webviewBaseline: WebViewStatus) =>
+`- name: "${name.replaceAll('"', "'")}"
+  description: "${description.replaceAll('"', "'")}"
+  supported:
+    baseline: ${baseline}
+    webviewBaseline: ${webviewBaseline}
+`;
+
+// First pull the bcd data from the CDN so that we can fix our
+// results to our hard coded bcd version rather than the data in the
+// web features repo.
+fetch(`http://unpkg.com/@mdn/browser-compat-data@${bcdVersion}/data.json`)
+	.then(response => response.json())
+	.then(bcd => {
+		const compat = new Compat(bcd);
+
+		// The core browser set is the set of browsers used to define
+		// the baseline status. We can be a bit cheeky here and just
+		// grab the publicly exposed list reference to add the webviews
+		// in bcd to that definition.
+		coreBrowserSet.push("webview_ios");
+		coreBrowserSet.push("webview_android");
+
+		let baseline = "";
+
+		for (const key in features) {
+			const feature = features[key];
+			let webviewBaseline: WebViewStatus = "unknown";
+
+			try {
+				const computedStatus = computeBaseline({
+					compatKeys: feature.compat_features as [string, ...string[]],
+					checkAncestors: true,
+				}, compat);
+				webviewBaseline = computedStatus.baseline;
+			} catch (e) {
+				// For cases where we couldn't comput this, we will
+				// fall back to "unknown".
+				// We should hunt down these cases and bring the
+				// list of impacted features down.
+				console.warn("[Baseline] Failed to generate", key)
+			}
+
+			baseline += getYml(
+				feature.name,
+				feature.description,
+				feature.status.baseline,
+				webviewBaseline);
+		}
+
+		writeFile(`_data/baseline.yml`, baseline);
+	})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"lib": [
+			"ES2021.String"
+		]
+	}
+}


### PR DESCRIPTION
It would be super handy to get a better sense of what WebView features will both impact baseline, and just generally where we are at.

The web features repo is very node friendly so it seems easier to work in that.
For that reason, I'm being a little funky and running a jekyll plugin that just executes a node script to create an untracked data file with our baseline results.

The important bit of this change is getting the data in a structured way we can work with so I've added a page that isn't linked from anywhere else with the results but I haven't styled it for the moment.