### PR TITLE
remove iPadOS platform

### DIFF
--- a/_clients/safari_ios.md
+++ b/_clients/safari_ios.md
@@ -1,5 +1,5 @@
 ---
-platforms: [macos, ios, ipados]
+platforms: [macos, ios]
 display_order: 11
 webview: false
 ---

--- a/_clients/wkwebview.md
+++ b/_clients/wkwebview.md
@@ -1,5 +1,5 @@
 ---
-platforms: [macos, ios, ipados]
+platforms: [macos, ios]
 display_order: 1
 upstream: safari_ios
 webview: true

--- a/_data/nicenames.yml
+++ b/_data/nicenames.yml
@@ -7,7 +7,6 @@ family:
   safari_ios: "Safari Browser"
 platform:
   ios: "iOS"
-  ipados: "iPadOS"
   android: "Android"
   windows: "Windows"
   macos: "macOS"

--- a/_features/api-permissions.md
+++ b/_features/api-permissions.md
@@ -26,9 +26,6 @@ stats: {
         },
         ios: {
             "*": "a"
-        },
-        ipados: {
-            "*": "a"
         }
     },
     androidwebview: {

--- a/_features/autofill.md
+++ b/_features/autofill.md
@@ -22,9 +22,6 @@ stats: {
         },
         ios: {
             "*": "u"
-        },
-        ipados: {
-            "*": "u"
         }
     },
     androidwebview: {

--- a/_features/cookies.md
+++ b/_features/cookies.md
@@ -28,9 +28,6 @@ stats: {
         },
         ios: {
             "*": "a"
-        },
-        ipados: {
-            "*": "a"
         }
     },
     androidwebview: {

--- a/_features/localhost.md
+++ b/_features/localhost.md
@@ -24,9 +24,6 @@ stats: {
         },
         ios: {
             "*": "y"
-        },
-        ipados: {
-            "*": "y"
         }
     },
     androidwebview: {

--- a/_features/scriptinjection.md
+++ b/_features/scriptinjection.md
@@ -21,9 +21,6 @@ stats: {
         },
         ios: {
             "*": "y"
-        },
-        ipados: {
-            "*": "y"
         }
     },
     androidwebview: {

--- a/_features/sharing.md
+++ b/_features/sharing.md
@@ -20,9 +20,6 @@ stats: {
         },
         ios: {
             "*": "a"
-        },
-        ipados: {
-            "*": "a"
         }
     },
     androidwebview: {

--- a/_features/template.md
+++ b/_features/template.md
@@ -21,9 +21,6 @@ stats: {
         },
         ios: {
             "*": "u"
-        },
-        ipados: {
-            "*": "u"
         }
     },
     androidwebview: {

--- a/_features/updates_cadence.md
+++ b/_features/updates_cadence.md
@@ -28,9 +28,6 @@ stats: {
         },
         ios: {
             "*": "u"
-        },
-        ipados: {
-            "*": "u"
         }
     },
     androidwebview: {

--- a/_features/web-storage.md
+++ b/_features/web-storage.md
@@ -23,9 +23,6 @@ stats: {
         },
         ios: {
             "*": "a"
-        },
-        ipados: {
-            "*": "a"
         }
     },
     androidwebview: {

--- a/_plugins/generated_features.rb
+++ b/_plugins/generated_features.rb
@@ -77,9 +77,6 @@ module Generated
 					"*" => "u"
 					},
 					"ios" => getVersions(feature, "webview_ios"),
-					"ipados" => {
-					"*" => "u"
-					}
 				},
 				"androidwebview" => {
 					"android" => getVersions(feature, "webview_android")

--- a/tools/baseline.ts
+++ b/tools/baseline.ts
@@ -39,9 +39,6 @@ fetch(`http://unpkg.com/@mdn/browser-compat-data@${bcdVersion}/data.json`)
 					},
 					ios: {
 						"*": "u"
-					},
-					ipados: {
-						"*": "u"
 					}
 				},
 				androidwebview: {


### PR DESCRIPTION
BCD does not have the iPadOS platform and Apple treats it very close to iOS. Therefore let's remove it to show more valuable data.